### PR TITLE
adds support for midigrid

### DIFF
--- a/player.lua
+++ b/player.lua
@@ -725,6 +725,7 @@ function init()
   midi_clock_in_device = midi.connect(1)
   midi_clock_in_device.event = function(data) midi_event(1, data) end
   
+  local grid = util.file_exists(_path.code.."midigrid") and include "midigrid/lib/mg_128" or grid
   grid_device = grid.connect(1)
   grid_device.key = grid_key
   


### PR DESCRIPTION
I believe this adds Midigrid support safely so that if the library is not present, timber will fall back to the Monome grid library.
I verified that the script loads and LP Mini MK3 works when midigrid is present, and that the script loads correctly when the midigrid lib is not installed. However, I don't have a Monome Grid to test that it works as expected with this change.

Also maybe you simply don't want to support midigrid and that's ok too.